### PR TITLE
Fix links to tutorial in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
   <a href="https://hands-on.cloud/serverless-framework-building-web-app-using-aws-lambda-amazon-api-gateway-s-3-dynamo-db-and-cognito-part-1/" target="_blank"><img src="https://raw.githubusercontent.com/hands-on-cloud/hands-on.cloud/master/src/pages/Serverless%20framework%20-%20Building%20Web%20App%20using%20AWS%20Lambda%2C%20Amazon%20API%20Gateway%2C%20S3%2C%20DynamoDB%20and%20Cognito%20-%20Part%201/Serverless-framework-Building-Web-App-using-AWS-Lambda-Amazon-API-Gateway-S3-DynamoDB-and-Cognito.png"></a>
 </p>
 
-This is [Serverless framework](https://serverless.com/) code demo for articles: 
-* `tag v.1.0` - [Serverless Framework - Building Web App Using AWS Lambda, Amazon API Gateway S3 DynamoDB And Cognito - Part-1](https://hands-on.cloud/serverless-framework-building-web-app-using-aws-lambda-amazon-api-gateway-s-3-dynamo-db-and-cognito-part-1/)
-* `tag v.2.0` - [Serverless Framework - Building Web App Using AWS Lambda, Amazon API Gateway S3 DynamoDB And Cognito - Part-2](https://hands-on.cloud/serverless-framework-building-web-app-using-aws-lambda-amazon-api-gateway-s-3-dynamo-db-and-cognito-part-2/)
+This is [Serverless framework](https://serverless.com/) code demo for articles:
+* `tag v.1.0` - [Serverless Framework - Building Web App Using AWS Lambda, Amazon API Gateway S3 DynamoDB And Cognito - Part-1](https://hands-on.cloud/serverless-framework-building-web-app-using-aws-lambda-amazon-api-gateway-s3-dynamodb-and-cognito-part-1/)
+* `tag v.2.0` - [Serverless Framework - Building Web App Using AWS Lambda, Amazon API Gateway S3 DynamoDB And Cognito - Part-2](https://hands-on.cloud/serverless-framework-building-web-app-using-aws-lambda-amazon-api-gateway-s3-dynamodb-and-cognito-part-2/)
 
 Please, read the article for more information.
 


### PR DESCRIPTION
Looks like the links were incorrectly formatted I found the actual article and updated the link in the readme